### PR TITLE
Fix universe_history returning empty data for CoinGeckoUniverse

### DIFF
--- a/CoinGeckoUniverse.cs
+++ b/CoinGeckoUniverse.cs
@@ -62,12 +62,12 @@ namespace QuantConnect.DataSource
         {
             var csv = line.Split(',');
             var coin = csv[0].ToUpperInvariant();
-            var sid = SecurityIdentifier.GenerateBase(typeof(CoinGecko), coin, Market.USA);
+            var sid = SecurityIdentifier.GenerateCrypto($"{coin}USD", Market.Coinbase);
 
             return new CoinGecko
             {
                 Symbol = new Symbol(sid, coin),
-                EndTime = date,
+                Time = date,
                 Value = decimal.Parse(csv[1], NumberStyles.Any, CultureInfo.InvariantCulture),
                 Volume = decimal.Parse(csv[2], NumberStyles.Any, CultureInfo.InvariantCulture),
                 MarketCap = decimal.Parse(csv[3], NumberStyles.Any, CultureInfo.InvariantCulture)

--- a/tests/CoinGeckoUniverseTests.cs
+++ b/tests/CoinGeckoUniverseTests.cs
@@ -41,6 +41,34 @@ namespace QuantConnect.DataLibrary.Tests
             AssertAreEqual(expected, result);
         }
 
+        [Test]
+        public void ReaderProducesCorrectSymbolAndTimeForUniverseHistory()
+        {
+            var universe = new CoinGeckoUniverse();
+            var config = new SubscriptionDataConfig(
+                typeof(CoinGeckoUniverse),
+                Symbol.Create("CoinGeckoUniverse", SecurityType.Base, Market.USA),
+                Resolution.Daily,
+                TimeZones.Utc,
+                TimeZones.Utc,
+                false, false, false);
+            var date = new DateTime(2025, 11, 6);
+
+            var btc = (CoinGecko)universe.Reader(config, "BTC,50000,123456789,1000000000000", date, false);
+            var eth = (CoinGecko)universe.Reader(config, "ETH,3000,987654321,500000000000", date, false);
+
+            Assert.AreEqual(date, btc.Time);
+
+            // must match the Crypto ID that CreateSymbol returns
+            Assert.AreEqual(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase), btc.Symbol);
+
+            // simulate the symbol filter applied during universe history selection
+            var filteredSymbols = new HashSet<Symbol> { btc.CreateSymbol(Market.Coinbase) };
+            var selected = new[] { btc, eth }.Where(x => filteredSymbols.Contains(x.Symbol)).ToList();
+            Assert.AreEqual(1, selected.Count);
+            Assert.AreEqual("BTC", selected[0].Coin);
+        }
+
         private void AssertAreEqual(object expected, object result, bool filterByCustomAttributes = false)
         {
             foreach (var propertyInfo in expected.GetType().GetProperties())


### PR DESCRIPTION
`universe_history` returned empty results due to two bugs in `CoinGeckoUniverse.Reader`:
  - Symbols were constructed using `SecurityIdentifier.GenerateBase` instead of `SecurityIdentifier.GenerateCrypto`, causing the symbol filter to discard all data points
  - `EndTime` was assigned instead of `Time`, causing `Time` to shift back one period and the temporal filter to discard the data point for the start date
  
  Closes [#9351](https://github.com/QuantConnect/Lean/issues/9351)